### PR TITLE
Destroy $scope on component unmount

### DIFF
--- a/src/angularTemplate.js
+++ b/src/angularTemplate.js
@@ -111,6 +111,12 @@ export default class ReactAngular extends React.Component {
     return false;
   }
 
+  componentWillUnmount() {
+    if (this.$scope) {
+      this.$scope.$destroy();
+    }
+  }
+
   render() {
     const { wrapperTag, className, wrapperAttrs, children } = this.props;
     const ref = (element) => this.$element = angular.element(element);


### PR DESCRIPTION
When the react component unmounts, the angular component needs to be cleaned-up.

This PR destroys the angular scope on component unmount, preventing any watchers / event handlers from running after the component is removed from the page.